### PR TITLE
Fix video asset image thumbnail parameter

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
@@ -257,7 +257,7 @@ pimcore.asset.video = Class.create(pimcore.asset.asset, {
                                                     image: data.id,
                                                     width: 265,
                                                     aspectratio: true,
-                                                    settime: true,
+                                                    setimage: true,
                                                     '_dc': date.getTime()
                                                 });
                                                 var cmp = Ext.getCmp("pimcore_asset_video_imagepreview_" + this.id);


### PR DESCRIPTION


<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Use `setimage` instead of `settime` for video thumbnail type `image_thumbnail_asset` 
(Route `pimcore_admin_asset_getvideothumbnail`)

Without this change it is not possible to set an image as thumbnail for a video.

